### PR TITLE
fix(ios): patch fmt/base.h to disable consteval (Xcode 26 compat)

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -103,4 +103,17 @@ post_install do |installer|
   # Patch SocketRocket to support TLS 1.3
   %x(patch Pods/SocketRocket/SocketRocket/SRSecurityPolicy.m -N < patches/ws-tls13.diff)
 
+  # Xcode 26+ clang rejects fmt 11's consteval-based FMT_STRING. fmt/base.h defines
+  # FMT_USE_CONSTEVAL unconditionally, so a -D flag can't override it; patch the
+  # header to force it to 0, which makes FMT_CONSTEVAL fall back to nothing/constexpr.
+  fmt_base_h = 'Pods/fmt/include/fmt/base.h'
+  if File.exist?(fmt_base_h)
+    contents = File.read(fmt_base_h)
+    patched = contents.gsub(/^(#  define FMT_USE_CONSTEVAL) 1$/, '\1 0')
+    if patched != contents
+      File.chmod(0644, fmt_base_h)
+      File.write(fmt_base_h, patched)
+    end
+  end
+
 end


### PR DESCRIPTION
## Summary
- Xcode 26's clang enforces `consteval` strictly and fmt 11's `FMT_STRING` macro no longer compiles. fmt/base.h defines `FMT_USE_CONSTEVAL` unconditionally inside `#if`/`#elif` chains, so a `-DFMT_USE_CONSTEVAL=0` build flag can't override it (the header redefines it).
- Adds a post_install step in `ios/Podfile` that flips the two `#define FMT_USE_CONSTEVAL 1` lines to `0` in the generated `Pods/fmt/include/fmt/base.h`, after every `pod install`.
- Without this, the iOS build fails with `error: call to consteval function 'fmt::basic_format_string<...>' is not a constant expression` in `fmt/format-inl.h`. Affects every branch building on Xcode 26.x.

## Test plan
- [ ] `cd ios && pod install` (the patch runs in post_install and edits `Pods/fmt/include/fmt/base.h`)
- [ ] Verify `grep "FMT_USE_CONSTEVAL 1" ios/Pods/fmt/include/fmt/base.h` returns nothing (all flipped to 0)
- [ ] `xcodebuild -workspace ios/jitsi-meet.xcworkspace -scheme JitsiMeet -configuration Release -sdk iphoneos -destination 'generic/platform=iOS' build CODE_SIGNING_ALLOWED=NO` succeeds
- [ ] Also passes on `-sdk iphonesimulator` for local dev builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)